### PR TITLE
[DepSync] Update health to v1.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/adshao/go-binance/v2 v2.8.2
 	github.com/cenkalti/backoff/v5 v5.0.2
 	github.com/cryptellation/dbmigrator v1.0.1
-	github.com/cryptellation/health v1.1.1
+	github.com/cryptellation/health v1.2.0
 	github.com/cryptellation/timeseries v1.0.2
 	github.com/cryptellation/version v1.1.0
 	github.com/jmoiron/sqlx v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/cryptellation/health v1.1.0 h1:/JloIjj/xTiM+kqtNQxbtZnhXDyLUCzogfI9A3
 github.com/cryptellation/health v1.1.0/go.mod h1:V5JEOyvgWHMerjn5XyXllNSRHxCeCxKmWtT8YCz6W3c=
 github.com/cryptellation/health v1.1.1 h1:LerBgSsMME5P6WGqG40uKoZI7QZ5ISpRGTJ1Toe4lWo=
 github.com/cryptellation/health v1.1.1/go.mod h1:V5JEOyvgWHMerjn5XyXllNSRHxCeCxKmWtT8YCz6W3c=
+github.com/cryptellation/health v1.2.0 h1:0j4k2VGRSgOTOX2ehrbcMQC9vkY5MLBuM0AaFRABSD8=
+github.com/cryptellation/health v1.2.0/go.mod h1:V5JEOyvgWHMerjn5XyXllNSRHxCeCxKmWtT8YCz6W3c=
 github.com/cryptellation/timeseries v1.0.2 h1:Vdrp4AZ7yfBlyANtU7vT9SptBQs8vdjXyjRnkX0C7iA=
 github.com/cryptellation/timeseries v1.0.2/go.mod h1:SxqmKOjn/l5AXZGaLGA47oScXzpTcXtnmfom88uZdaY=
 github.com/cryptellation/version v1.1.0 h1:guPP4DVPj0Ie1Fnmmiv3VM4xqG7ZMJGjvrS41mHg5Pc=


### PR DESCRIPTION
## Dependency Update

This merge request updates the dependency **github.com/cryptellation/health** to version **v1.2.0**.

### Changes
- Updated dependency: `github.com/cryptellation/health`
- New version: `v1.2.0`

This update was automatically generated by DepSync.